### PR TITLE
TST: stats.skewnorm.fit: strengthen test of improvement when data is highly skewed

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -9221,6 +9221,8 @@ class skewnorm_gen(rv_continuous):
         shape parameter ``a`` will be infinite.
         \n\n""")
     def fit(self, data, *args, **kwds):
+        if kwds.pop("superfit", False):
+            return super().fit(data, *args, **kwds)
         if isinstance(data, CensoredData):
             if data.num_censored() == 0:
                 data = data._uncensor()

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -33,7 +33,7 @@ from scipy.special import xlogy, polygamma, entr
 from scipy.stats._distr_params import distcont, invdistcont
 from .test_discrete_basic import distdiscrete, invdistdiscrete
 from scipy.stats._continuous_distns import FitDataError, _argus_phi
-from scipy.optimize import root, fmin
+from scipy.optimize import root, fmin, differential_evolution
 from itertools import product
 
 # python -OO strips docstrings
@@ -3867,14 +3867,29 @@ class TestSkewNorm:
         a7m, loc7m, scale7m = stats.skewnorm.fit(-rvs, method='mm')
         assert_allclose([a7m, loc7m, scale7m], [-a7p, -loc7p, scale7p])
 
-        # test that MLE is resistant to finding the wrong local optimum (see gh-19332)
-        a_correct, loc_correct, scale_correct = -1.60957, 2.2990, 2.46210
-        for n in range(8):
-            rvs = np.array([-5, -1, n / 100_000] + 12 * [1] + [5])
-            a8, loc8, scale8 = stats.skewnorm.fit(rvs)
-            assert_allclose(
-                (a8, loc8, scale8), (a_correct, loc_correct, scale_correct), atol=1e-4
-            )
+    def test_fit_gh19332(self):
+        # When the skewness of the data was high, `skewnorm.fit` fell back on
+        # generic `fit` behavior with a bad guess of the skewness parameter.
+        # Test that this is improved; `skewnorm.fit` is now better at finding
+        # the global optimum when the sample is highly skewed. See gh-19332.
+        x = np.array([-5, -1, 1 / 100_000] + 12 * [1] + [5])
+
+        params = stats.skewnorm.fit(x)
+        res = stats.skewnorm.nnlf(params, x)
+
+        # Compare overridden fit against generic fit
+        params_super = stats.skewnorm.fit(x, superfit=True)
+        ref = stats.skewnorm.nnlf(params_super, x)
+        assert res < ref - 0.5
+
+        # Compare overridden fit against stats.fit
+        rng = np.random.default_rng(9842356982345693637)
+        bounds = {'a': (-5, 5), 'loc': (-10, 10), 'scale': (1e-16, 10)}
+        def optimizer(fun, bounds):
+            return differential_evolution(fun, bounds, seed=rng)
+
+        fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
+        np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
 
 class TestExpon:


### PR DESCRIPTION
#### Reference issue
scipy/scipy#19333

#### What does this implement/fix?
Addresses https://github.com/scipy/scipy/pull/19333#issuecomment-1743202305. I decided that it was not important to test with both signs of the data. (When the sign of the data was flipped, `fit` finds the better optimum in `main`, at least for `n=1`. Perhaps with a different `n` I could have found a better test, but I didn't bother.)
