### PR TITLE
TST: Add CDF-PPF roundtrip check for skewnorm

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3978,6 +3978,13 @@ class TestSkewNorm:
         fit_result = stats.fit(stats.skewnorm, x, bounds, optimizer=optimizer)
         np.testing.assert_allclose(params, fit_result.params, rtol=1e-4)
 
+    def test_cdf_ppf_roundtrip_gh20124(self):
+        x0 = 0.02
+        skew = 500
+        q = stats.skewnorm.cdf(x0, skew, 0, 1)
+        x1 = stats.skewnorm.ppf(q, skew, 0, 1)
+        assert_almost_equal(x1, x0)
+
 
 class TestExpon:
     def test_zero(self):


### PR DESCRIPTION
This is a regression test for gh-20124.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message

Depending on your changes, you can skip CI operations and save time and energy: 
http://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
